### PR TITLE
feat(App) Symfony 4 support

### DIFF
--- a/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('data_dog_audit');
+        $treeBuilder = new TreeBuilder('data_dog_audit');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('data_dog_audit');
+        }
 
         $rootNode
             ->children()

--- a/src/DataDog/AuditBundle/Resources/config/services.yml
+++ b/src/DataDog/AuditBundle/Resources/config/services.yml
@@ -27,3 +27,7 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.controller }
 
+  DataDog\AuditBundle\Command\:
+        resource: '../../Command/*'
+        tags: ['console.command']
+


### PR DESCRIPTION
 * 3rd-party bundle commands are no longer automatically discovered, added config on services.yml to discover.
 * symfony 4 support for getRootNode  deprecation.