### PR TITLE
change framework bundle permitted versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "ext-pdo": "*",
     "ext-pdo_sqlite": "*",
 
-    "symfony/symfony": "^3.0|^4.0|^4.4",
+    "symfony/symfony": "^3.0|^4.0|^4.4|^5.4|^6.4",
     "doctrine/orm": "^2.5",
     "doctrine/doctrine-bundle": "^1.6",
     "doctrine/doctrine-fixtures-bundle": "^2.2",


### PR DESCRIPTION
This change will allow to install bundle on Symfony 6.4 versions