### PR TITLE
Applying Migration to be compatible with Symfony 6.4

### DIFF
--- a/src/DataDog/AuditBundle/Annotations/NTIAudit.php
+++ b/src/DataDog/AuditBundle/Annotations/NTIAudit.php
@@ -2,13 +2,15 @@
 
 namespace DataDog\AuditBundle\Annotations;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
  * Class NTIAudit
  * @package DataDog\AuditBundle\Annotations
- * @Annotation
+ * 
  */
+#[Attribute(Attribute::TARGET_CLASS)]
 class NTIAudit {
 
 }

--- a/src/DataDog/AuditBundle/Controller/AuditLogController.php
+++ b/src/DataDog/AuditBundle/Controller/AuditLogController.php
@@ -2,17 +2,13 @@
 
 namespace DataDog\AuditBundle\Controller;
 
-use AppBundle\Util\DataTable\DataTableOptionsProcessor;
-use AppBundle\Util\Rest\DataTableRestResponse;
-use AppBundle\Util\Rest\RestResponse;
+use DataDog\AuditBundle\Util\DataTable\DataTableOptionsProcessor;
+use DataDog\AuditBundle\Util\Rest\DataTableRestResponse;
 use DataDog\AuditBundle\Service\AuditLogService;
-use JMS\Serializer\SerializationContext;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use JMS\Serializer\SerializerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -20,8 +16,24 @@ use Symfony\Component\Routing\Annotation\Route;
  * @package DataDog\AuditBundle\Controller
  * @Route("/")
  */
-class AuditLogController extends Controller {
+class AuditLogController extends AbstractController {
 
+    /** @var ContainerInterface */
+    protected $container;
+
+    /** @var AuditLogService */
+    protected $auditLogService;
+
+    /** @var SerializerInterface */
+    protected $serializer;
+
+    public function __construct(ContainerInterface $container, AuditLogService $auditLogService, SerializerInterface $serializer)
+    {
+        $this->container = $container;
+        $this->auditLogService = $auditLogService;
+        $this->serializer = $serializer;
+    }
+    
     // REST Methods
     /**
      * @Route("/rest/getAll", name="nti_rest_audit_log_get_all", options={"expose"=true}, methods={"GET"})
@@ -30,8 +42,8 @@ class AuditLogController extends Controller {
      */
     public function getAllAction(Request $request) {
         $options = DataTableOptionsProcessor::GetOptions($request);
-        $result = $this->get(AuditLogService::class)->getAll($options);
-        $logs = json_decode($this->container->get('jms_serializer')->serialize($result["data"], 'json') ,true);
+        $result = $this->auditLogService->getAll($options);
+        $logs = json_decode($this->serializer->serialize($result["data"], 'json') ,true);
         $result["data"] = $logs;
         return new DataTableRestResponse($result);
     }

--- a/src/DataDog/AuditBundle/DBAL/AuditLogger.php
+++ b/src/DataDog/AuditBundle/DBAL/AuditLogger.php
@@ -2,9 +2,7 @@
 
 namespace DataDog\AuditBundle\DBAL;
 
-use Doctrine\DBAL\Logging\SQLLogger;
-
-class AuditLogger implements SQLLogger
+class AuditLogger
 {
     /**
      * @var callable

--- a/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/Configuration.php
@@ -18,11 +18,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('data_dog_audit');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            $rootNode = $treeBuilder->root('data_dog_audit');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
+++ b/src/DataDog/AuditBundle/DependencyInjection/DataDogAuditExtension.php
@@ -25,7 +25,7 @@ class DataDogAuditExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
-        $auditSubscriber = $container->getDefinition('datadog.event_subscriber.audit');
+        $auditSubscriber = $container->getDefinition('datadog.event_listener.audit');
 
         if (isset($config['audited_entities']) && !empty($config['audited_entities']))
             $auditSubscriber->addMethodCall('addAuditedEntities', array($config['audited_entities']));

--- a/src/DataDog/AuditBundle/Entity/Association.php
+++ b/src/DataDog/AuditBundle/Entity/Association.php
@@ -5,54 +5,64 @@ namespace DataDog\AuditBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Entity
- * @ORM\Entity(repositoryClass="DataDog\AuditBundle\Repository\AssociationRepository")
- * @ORM\Table(name="audit_associations")
+ * 
+ * Association
+ * 
  */
+#[ORM\Table(name: 'audit_associations')]
+#[ORM\Entity(repositoryClass: 'DataDog\AuditBundle\Repository\AssociationRepository')]
+#[ORM\HasLifecycleCallbacks()]
 class Association
 {
     /**
-     * @ORM\Id
-     * @ORM\Column(type="bigint")
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @var bigint
      */
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
     /**
-     * @ORM\Column(length=128)
+     * 
      */
+    #[ORM\Column(length: 128)]
     private $typ;
 
     /**
-     * @ORM\Column(length=128)
+     * 
      */
+    #[ORM\Column(length: 128)]
     private $tbl;
 
     /**
-     * @ORM\Column(nullable=true)
+     * 
      */
+    #[ORM\Column(nullable: true)]
     private $label;
 
     /**
-     * @ORM\Column
+     * 
      */
+    #[ORM\Column()]
     private $fk;
 
     /**
-     * @ORM\Column
+     * 
      */
+    #[ORM\Column()]
     private $class;
 
     /**
-     *@ORM\Column(type="datetime")
+     *  @var datetime
      */
+    #[ORM\Column(type: 'datetime')]
     private $createdOn;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="app_name", type="text", nullable=true)
+     * 
      */
+    #[ORM\Column(name: 'app_name', type: 'text', nullable: true)]
     private $appName;
     
     /**

--- a/src/DataDog/AuditBundle/Entity/AuditLog.php
+++ b/src/DataDog/AuditBundle/Entity/AuditLog.php
@@ -5,60 +5,74 @@ namespace DataDog\AuditBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Entity
- * @ORM\Entity(repositoryClass="DataDog\AuditBundle\Repository\AuditLogRepository")
- * @ORM\Table(name="audit_logs")
+ * 
+ * AuditLog
+ * 
  */
+#[ORM\Table(name: 'audit_logs')]
+#[ORM\Entity(repositoryClass: 'DataDog\AuditBundle\Repository\AuditLogRepository')]
+#[ORM\HasLifecycleCallbacks()]
 class AuditLog
 {
     /**
-     * @ORM\Id
-     * @ORM\Column(type="bigint")
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * 
+     * @var bigint
+     * 
      */
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
     /**
-     * @ORM\Column(length=12)
+     * 
      */
+    #[ORM\Column(length: 12)]
     private $action;
 
     /**
-     * @ORM\Column(length=128)
+     * 
      */
+    #[ORM\Column(length: 12)]
     private $tbl;
 
     /**
-     * @ORM\OneToOne(targetEntity="Association")
-     * @ORM\JoinColumn(nullable=false)
+     * 
+     * 
      */
+    #[ORM\OneToOne(targetEntity: Association::class)]
+    #[ORM\JoinColumn(nullable:false)]
     private $source;
 
     /**
-     * @ORM\OneToOne(targetEntity="Association")
+     * 
      */
+    #[ORM\OneToOne(targetEntity: Association::class)]
     private $target;
 
     /**
-     * @ORM\OneToOne(targetEntity="Association")
+     * 
      */
+    #[ORM\OneToOne(targetEntity: Association::class)]
     private $blame;
 
     /**
-     * @ORM\Column(type="json_array", nullable=true)
+     * 
      */
+    #[ORM\Column(type:'json_array', nullable:true)]
     private $diff;
 
     /**
-     * @ORM\Column(type="datetime")
+     * @var datetime
      */
+    #[ORM\Column(type:'datetime')]
     private $loggedAt;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="app_name", type="text", nullable=true)
+     * 
      */
+    #[ORM\Column(name:'app_name', type:'text', nullable:true)]
     private $appName;    
 
     /**

--- a/src/DataDog/AuditBundle/Entity/AuditRequest.php
+++ b/src/DataDog/AuditBundle/Entity/AuditRequest.php
@@ -5,54 +5,54 @@ namespace DataDog\AuditBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Table(name="audit_request")
- * @ORM\Entity(repositoryClass="DataDog\AuditBundle\Repository\AuditRequestRepository")
- * @ORM\HasLifecycleCallbacks()
+ * 
+ * AuditResquest
+ * 
  */
+#[ORM\Table(name: 'audit_request')]
+#[ORM\Entity(repositoryClass: 'DataDog\AuditBundle\Repository\AuditLogRepository')]
+#[ORM\HasLifecycleCallbacks()]
 class AuditRequest
 {
     /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var integer
+     * 
      */
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     private $id;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="method", type="string", length=255, nullable=true)
+     * 
      */
+    #[ORM\Column(name:"method", type:"string", length:255, nullable:true)]
     private $method;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="controller", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name:"controller", type:"string", length:255, nullable:true)]
     private $controller;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="route", type="string", length=1000, nullable=true)
      */
+    #[ORM\Column(name:"route", type:"string", length:1000, nullable:true)]
     private $route;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="route_params", type="text", nullable=true)
      */
+    #[ORM\Column(name:"route_params", type:"text", nullable:true)]
     private $routeParams;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="ip", type="string", length=255, nullable=true)
+     * 
      */
+    #[ORM\Column(name:"ip", type:"string", length:255, nullable:true)]
     private $ip;
 
     /**
@@ -60,41 +60,37 @@ class AuditRequest
      *
      * @ORM\Column(name="user_name", type="string", length=500, nullable=true)
      */
+    #[ORM\Column(name:"ip", type:"string", length:255, nullable:true)]
     private $userName;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="portal", type="string", length=500, nullable=true)
      */
+    #[ORM\Column(name:"portal", type:"string", length:500, nullable:true)]
     private $portal;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="query_data", type="text", nullable=true)
      */
+    #[ORM\Column(name:"query_data", type:"text", nullable:true)]
     private $queryData;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="data", type="text", nullable=true)
      */
+    #[ORM\Column(name:"data", type:"text", nullable:true)]
     private $data;
 
     /**
      * @var \DateTime
-     *
-     * @ORM\Column(name="created_on", type="datetime", nullable=false)
      */
+    #[ORM\Column(name:"created_on", type:"datetime", nullable:false)]
     private $createdOn;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="app_name", type="text", nullable=true)
      */
+    #[ORM\Column(name:"app_name", type:"text", nullable:true)]
     private $appName;
 
     /**

--- a/src/DataDog/AuditBundle/Repository/AssociationRepository.php
+++ b/src/DataDog/AuditBundle/Repository/AssociationRepository.php
@@ -3,9 +3,16 @@
 namespace DataDog\AuditBundle\Repository;
 
 use DataDog\AuditBundle\Entity\Association;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 
-class AssociationRepository extends \Doctrine\ORM\EntityRepository
+class AssociationRepository extends ServiceEntityRepository
 {
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Association::class);
+    }
+
     public function findAudit(\DateTime $dateStart, \DateTime $dateEnd){
         $qb = $this->createQueryBuilder('a');
         $qb ->select('a')

--- a/src/DataDog/AuditBundle/Repository/AuditLogRepository.php
+++ b/src/DataDog/AuditBundle/Repository/AuditLogRepository.php
@@ -3,10 +3,17 @@
 namespace DataDog\AuditBundle\Repository;
 
 use DataDog\AuditBundle\Entity\AuditLog;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 
-class AuditLogRepository extends \Doctrine\ORM\EntityRepository
+class AuditLogRepository extends ServiceEntityRepository
 {
     const MAX_RESULTS = 1000;
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AuditLog::class);
+    }
 
     public function findAudit(\DateTime $dateStart, \DateTime $dateEnd){
         $qb = $this->createQueryBuilder('a');

--- a/src/DataDog/AuditBundle/Repository/AuditRequestRepository.php
+++ b/src/DataDog/AuditBundle/Repository/AuditRequestRepository.php
@@ -3,9 +3,17 @@
 namespace DataDog\AuditBundle\Repository;
 
 use DataDog\AuditBundle\Entity\AuditRequest;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 
-class AuditRequestRepository extends \Doctrine\ORM\EntityRepository
+class AuditRequestRepository extends ServiceEntityRepository
 {
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AuditRequest::class);
+    }
+
     public function findAudit(\DateTime $dateStart, \DateTime $dateEnd){
         $qb = $this->createQueryBuilder('a');
         $qb ->select('a')

--- a/src/DataDog/AuditBundle/Resources/config/services.yml
+++ b/src/DataDog/AuditBundle/Resources/config/services.yml
@@ -8,22 +8,17 @@ services:
     resource: '../../../../../src/DataDog/*'
     # you can exclude directories or files
     # but if a service is unused, it's removed anyway
-    exclude: '../../../../../src/DataDog/AuditBundle/{Entity,Repository,Service}'
-
-  # actual services to be tagged as public
-  DataDog\AuditBundle\Service\:
-    resource: '../../../../../src/DataDog/AuditBundle/Service'
-    public: true
-
-  datadog.event_subscriber.audit:
-    class: DataDog\AuditBundle\EventSubscriber\AuditSubscriber
-    arguments: ["@security.token_storage"]
-    tags:
-      - { name: doctrine.event_subscriber, connection: default }
+    # exclude: '../../../../../src/DataDog/AuditBundle/{Entity,Repository,Service}'
 
   datadog.event_listener.audit:
+    class: DataDog\AuditBundle\EventListener\AuditListener
+    arguments: ["@security.token_storage", "@service_container", "@doctrine.orm.entity_manager"]
+    tags:
+      - { name: doctrine.event_listener, event: flush }
+
+  datadog.event_listener.audit_controller:
     class: DataDog\AuditBundle\EventListener\ControllerListener
-    arguments: ['@service_container']
+    arguments: ['@service_container', "@doctrine.orm.entity_manager", "@security.token_storage"]
     tags:
       - { name: kernel.event_listener, event: kernel.controller }
 

--- a/src/DataDog/AuditBundle/Service/AuditLogService.php
+++ b/src/DataDog/AuditBundle/Service/AuditLogService.php
@@ -2,8 +2,7 @@
 
 namespace DataDog\AuditBundle\Service;
 
-use DataDog\AuditBundle\Entity\AuditLog;
-use PHPUnit\Runner\Exception;
+use DataDog\AuditBundle\Repository\AuditLogRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -15,13 +14,17 @@ class AuditLogService {
     /** @var ContainerInterface $container */
     private $container;
 
+    /** @var AuditLogRepository $auditLogRepository */
+    private $auditLogRepository;
+
     /**
      * AuditLogService constructor.
      * @param ContainerInterface $container
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, AuditLogRepository $auditLogRepository)
     {
         $this->container = $container;
+        $this->auditLogRepository = $auditLogRepository;
     }
 
     /**
@@ -31,9 +34,9 @@ class AuditLogService {
      * @return mixed
      */
     public function getAll($options = array()) {
-        $connectionName = $this->container->getParameter('nti_audit.database.connection_name');
-        $em = $this->container->get('doctrine')->getManager($connectionName);
-        $logs = $em->getRepository(AuditLog::class)->findByOptions($options);
+        // $connectionName = $this->container->getParameter('nti_audit.database.connection_name');
+        // $em = $this->container->get('doctrine')->getManager($connectionName);
+        $logs = $this->auditLogRepository->findByOptions($options);
         return $logs;
     }
 }

--- a/src/DataDog/AuditBundle/Util/DataTable/DataTableOptionsProcessor.php
+++ b/src/DataDog/AuditBundle/Util/DataTable/DataTableOptionsProcessor.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace DataDog\AuditBundle\Util\DataTable;
+
+/**
+ * Class DataTableOptionsProcessor
+ * @package DataDog\AuditBundle\Util\DataTable
+ */
+class DataTableOptionsProcessor {
+
+    public static function GetOptions($request) {
+        $draw = $request->get('draw');
+        $search = $request->get('search');
+        if(is_array($search) && isset($search["value"])) {
+            $search = $search["value"];
+        }
+        $orderBy = $request->get('order');
+        $columns = $request->get('columns');
+        $length = $request->get('length') ?? $request->get('limit');
+        $start = $request->get('start');
+
+        $filters = array();
+
+        // Prepare the filters
+        foreach($request->query->all() as $key => $value) {
+            if(FALSE !== strpos($key, "filter_") ){
+                $filters[str_replace("filter_", "", $key)] = $value;
+            }
+        }
+
+        // Manage sort by
+        $order = null;
+        $sortBy = null;
+        if(is_array($orderBy) && count($orderBy) > 0 && isset($orderBy[0]['column'])) {
+            if(is_array($columns) && isset($columns[$orderBy[0]['column']])) {
+                $sortBy = $columns[$orderBy[0]['column']]['data'];
+            }
+            if(isset($orderBy[0]['dir'])) {
+                $order = $orderBy[0]['dir'];
+            }
+        }
+
+        return array(
+            "draw" => $draw,
+            "search" => $search,
+            "length" => $length,
+            "start" => $start,
+            "filters" => $filters,
+            "orderBy" => $order,
+            "sortBy" => $sortBy,
+            "columns" => $columns,
+        );
+    }
+}

--- a/src/DataDog/AuditBundle/Util/Rest/DataTableRestResponse.php
+++ b/src/DataDog/AuditBundle/Util/Rest/DataTableRestResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DataDog\AuditBundle\Util\Rest;
+
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class DataTableRestResponse extends JsonResponse {
+    public function __construct($data, $status = 200, $message = "", $errors = null, $headers = array())
+    {
+        // Prepare form errors if provided
+        if($errors instanceof Form) {
+            $errors = $this->getFormErrors($errors);
+        }
+
+        $structure = array(
+            "has_error" => $this->isError($status),
+            "additional_errors" => $errors,
+            "code" => $status,
+            "message" => ($message != "") ? $message : null,
+        );
+
+        $structure = array_merge($structure, $data);
+
+        parent::__construct($structure, $status, $headers);
+    }
+
+    private function isError($status) {
+        if($status >= 200 && $status <= 299) { return false; }
+        if($status >= 300 && $status <= 399) { return false; }
+        if($status >= 400 && $status <= 499) { return true; }
+        if($status >= 500 && $status <= 599) { return true; }
+        return true;
+    }
+}


### PR DESCRIPTION
Applying Migration to be compatible with Symfony 6.4

1. Annotation replaced to used Attributes
2. Command Migration
3. Controller Migration
4. Repository Migration
5. Service Migration
6. Dependency Injection inclusion
7. Remove Event Suscribers
