### PR TITLE
fix issue with Deprecated Using ArrayAccess on FieldMapping

### DIFF
--- a/src/DataDog/AuditBundle/EventListener/AuditListener.php
+++ b/src/DataDog/AuditBundle/EventListener/AuditListener.php
@@ -412,10 +412,10 @@ class AuditListener
     protected function id(EntityManager $em, $entity)
     {
         $meta = $em->getClassMetadata(get_class($entity));
-        $pk = $meta->getSingleIdentifierFieldName();
+        $pk = $meta->getIdentifier()[0];
         $pk = $this->value(
             $em,
-            Type::getType($meta->fieldMappings[$pk]['type']),
+            Type::getType($meta->fieldMappings[$pk]->type),
             $meta->getReflectionProperty($pk)->getValue($entity)
         );
         return $pk;


### PR DESCRIPTION
- Apply fix to the following warning:

User Deprecated: Using ArrayAccess on Doctrine\\ORM\\Mapping\\FieldMapping is deprecated and will not be possible in Doctrine ORM 4.0. Use the corresponding property instead 